### PR TITLE
Patch for Issue 1: port exhaustion on windows

### DIFF
--- a/bulbs/rest.py
+++ b/bulbs/rest.py
@@ -64,7 +64,7 @@ class Resource(object):
         assert method in ("GET","POST","DELETE"), \
             "Only GET, POST, DELETE are allowed."
 
-        headers = {'Accept': 'application/json'}
+        headers = {'Accept': 'application/json', 'connection': 'close'}
 
         # httplib2 let's you cache http responses with memcache 
         # really cool, look into that later


### PR DESCRIPTION
fixed rest.py to close http connections to avoid port exhaustion on windows machines (issue 1)
Signed-off-by: Paul Melby paulmelby@gmail.com
