### PR TITLE
Use urlparse

### DIFF
--- a/bulbs/config.py
+++ b/bulbs/config.py
@@ -5,14 +5,18 @@
 #
 from utils import get_logger
 from logging import DEBUG, ERROR, StreamHandler
-
+from urlparse import urlparse
 
 class Config(object):
 
     def __init__(self,root_uri,username=None,password=None,log_level=ERROR):
-        self.root_uri = root_uri
-        self.username = username
-        self.password = password
+        parsed_uri =  urlparse(root_uri)
+        self.root_uri = parsed_uri.scheme + "://" + parsed_uri.hostname + ":" + str(parsed_uri.port) + parsed_uri.path
+        self.username = parsed_uri.username
+        self.password = parsed_uri.password
+        if (username is not None and password is not None):
+            self.username = username
+            self.password = password
         self.id_var = "eid"
         self.type_var = "element_type"
         self.label_var = "label"
@@ -29,4 +33,5 @@ class Config(object):
         log = get_logger(__name__)
         log.root.setLevel(self.log_level)
         log.root.addHandler(self.log_handler())
+
 


### PR DESCRIPTION
Use urlparse and extract connection data and username:password. Setting username and password parameters  overrides parsed values.

This is nice to use with os.environ["NEO4J_REST_URL"] which is set on Heroku instances for you.
I'm using this, which uses the default "local" neo4j instance or the Heroku addon if its set:

``` python
if ('NEO4J_REST_URL' in os.environ):    
    neo4jUrl = os.environ["NEO4J_REST_URL"]
else: 
    neo4jUrl = NEO4J_URI

class Model(object):
    def __init__(self):
        self.config = Config(neo4jUrl)
        ...
```

Waiting for 0.3 :P
Alejandro.
