### PR TITLE
Look before you leap + Rexster+neo4j compatibility

### DIFF
--- a/bulbs/gremlin.groovy
+++ b/bulbs/gremlin.groovy
@@ -90,27 +90,57 @@ def index_count(index_name, key, value) {
 }
 
 def get_or_create_vertex_index(index_name, index_params) {
-  index = g.idx(index_name)
-  if (index == null) {
-    if (index_params == null) {
-      index = g.createManualIndex(index_name, Vertex.class)
-    } else {
-      index = g.createManualIndex(index_name, Vertex.class, index_params)
+  def getOrCreateVertexIndex = { 
+    index = g.idx(index_name)
+    if (index == null) {
+      if (index_params == null) {
+        index = g.createManualIndex(index_name, Vertex.class)
+      } else {
+        index = g.createManualIndex(index_name, Vertex.class, index_params)
+      }
+    }
+    return index
+  }
+  def transaction = { final Closure closure ->
+    g.setMaxBufferSize(0);
+    g.startTransaction();
+    try {
+      results = closure();
+      g.stopTransaction(TransactionalGraph.Conclusion.SUCCESS);
+      return results; 
+    } catch (e) {
+      g.stopTransaction(TransactionalGraph.Conclusion.FAILURE);
+      throw e;
     }
   }
-  return index
+  return transaction(getOrCreateVertexIndex);
 }
 
 def get_or_create_edge_index(index_name, index_params) {
-  index = g.idx(index_name)
-  if (index == null) {
-    if (index_params == null) {
-      index = g.createManualIndex(index_name, Edge.class)
-    } else {
-      index = g.createManualIndex(index_name, Edge.class, index_params)
+  def getOrCreateEdgeIndex = { 
+    index = g.idx(index_name)
+    if (index == null) {
+      if (index_params == null) {
+        index = g.createManualIndex(index_name, Edge.class)
+      } else {
+        index = g.createManualIndex(index_name, Edge.class, index_params)
+      }
+    }
+    return index
+  }
+  def transaction = { final Closure closure ->
+    g.setMaxBufferSize(0);
+    g.startTransaction();
+    try {
+      results = closure();
+      g.stopTransaction(TransactionalGraph.Conclusion.SUCCESS);
+      return results; 
+    } catch (e) {
+      g.stopTransaction(TransactionalGraph.Conclusion.FAILURE);
+      throw e;
     }
   }
-  return index
+  return transaction(getOrCreateEdgeIndex);
 }
 
 // Utils


### PR DESCRIPTION
Okay so this is two separate things but they're close enough that I'm not really confident enough in my git-fu to have them in separate pull requests.

Rexster + neo4j will get quite error if you pass in a null as the third argument to createManualIndex rather than use the two argument version.

Look before you leap on conditionals so as to not accidently suppress exceptions by catching only the wrong type. Unfortunately Gremlin throws
the fairly generic RuntimeError for creating an index when one already
exists so catching by exception type isn't really an option.
