### PR TITLE
Fix in build_path

### DIFF
--- a/bulbs/utils.py
+++ b/bulbs/utils.py
@@ -115,7 +115,7 @@ def get_key_value(key, value, pair):
 def build_path(*args):
     #path = "/".join(map(str,args))
     # don't include segment if it's None
-    segments = [str(segment) for segment in args if segment]
+    segments = [str(segment) for segment in args if segment is not None]
     # Only need to quote URL for index keys/values -- do it at the client level
     #segments = [quote_plus(str(segment)) for segment in args if segment]
     path = "/".join(segments)


### PR DESCRIPTION
build_path should only omit segments which are None, not segments which evaluate to False (e.g. 0)

The former behavior resulted in a bug, e.g. when calling rexster.client.get_vertex with _id=0, a generator with all vertices is returned instead of the requested one.
