### PR TITLE
Fix : escape slash characters in client requests. 

### DIFF
--- a/bulbs/neo4jserver/client.py
+++ b/bulbs/neo4jserver/client.py
@@ -844,7 +844,7 @@ class Neo4jClient(Client):
 
         """
         # converting all values to strings because that's how they're stored
-        key, value = quote(key), quote(str(value))
+        key, value = quote(key, safe=''), quote(str(value), safe='')
         path = build_path(index_path, "node", index_name, key, value)
         params = None
         return self.request.get(path, params)


### PR DESCRIPTION
When requesting with values containing urls, slash characters caused conflicts with Rextster api. Values were interpreted as parts of url.
