### PR TITLE
Support for cypher queries returning multiple values

### DIFF
--- a/bulbs/utils.py
+++ b/bulbs/utils.py
@@ -56,7 +56,12 @@ def initialize_elements(client,response):
     # return a generator of initialized elements.
     if response.total_size > 0:
         for result in response.results:
-            yield initialize_element(client,result)
+            if isinstance(result,list):
+                yield [initialize_element(client, res) for res in result]
+            elif isinstance(result,dict):
+                yield dict((column,initialize_element(client, res)) for column,res in result.iteritems())
+            else:
+                yield initialize_element(client,result)
 
 
 def initialize_element(client,result):


### PR DESCRIPTION
This commit adds support for cypher queries returning multiple values.
It does so by returning a list of objects if there is only 1 value, or a list of dictionaries if there are more than 1 value and the values are named or a list of list if there are more than 1 value and the values are not named
