### PR TITLE
Custom step

### DIFF
--- a/bulbs/element.py
+++ b/bulbs/element.py
@@ -346,7 +346,7 @@ class Element(object):
         """
         Execute a custom gremlin step starting from the current element.
         Do not use "_id" as a key in params.
-	e.g.: >>> node.custom_step('outE(x).bothV',{'x':'A'})
+        e.g.: >>> node.custom_step('outE(x).bothV',{'x':'A'})
         """
         full_script = 'g.v(_id).'+script
         params['_id']=self._id

--- a/bulbs/element.py
+++ b/bulbs/element.py
@@ -342,6 +342,17 @@ class Element(object):
         log.debug("This is deprecated; use data() instead.")
         return self.data()
 
+    def custom_step(self,script,params={}):
+        """
+        Execute a custom gremlin step starting from the current element.
+        Do not use "_id" as a key in params.
+	e.g.: >>> node.custom_step('outE(x).bothV',{'x':'A'})
+        """
+        full_script = 'g.v(_id).'+script
+        params['_id']=self._id
+        resp = self._client.gremlin(full_script,params)
+        return initialize_elements(self._client,resp)
+
 
 
 #


### PR DESCRIPTION
James, 

this is the functionality I mentioned before.
This allows the usage of `node.custom_step('friend')` or `node.custom_step('out.out').

I made a few changes, which I believe are rather independent from the implementation details of lower layers. I send them in different pull requests.
