### PR TITLE
Add create_unique_vertex() index method.

### DIFF
--- a/bulbs/neo4jserver/client.py
+++ b/bulbs/neo4jserver/client.py
@@ -878,6 +878,33 @@ class Neo4jClient(Client):
         path = build_path(index_path, vertex_path, index_name, key, value)
         params = None
         return self.request.get(path, params)
+
+    def create_unique_vertex(self, index_name, key, value, data=None):
+        """
+        Create unique (based on the key / value pair) vertex with the properties
+        described by data.
+
+        :param index_name: Name of the index.
+        :type index_name: str
+
+        :param key: Name of the key.
+        :type key: str
+
+        :param value: Value of the key.
+        :type value: str
+
+        :param data: Properties of the new element.
+        :type data: dict
+
+        :rtype: Neo4jResponse
+
+        """
+        data = {} if data is None else data
+        data = self._remove_null_values(data)
+        path = (build_path(index_path, vertex_path, index_name) +
+                '?uniqueness=get_or_create')
+        params = {'key': key, 'value': value, 'properties': data}
+        return self.request.post(path, params)
         
     def query_vertex(self, index_name, query):
         """

--- a/bulbs/neo4jserver/index.py
+++ b/bulbs/neo4jserver/index.py
@@ -337,6 +337,35 @@ class Index(object):
             result = get_one_result(resp)
             return initialize_element(self.client,result)
 
+    def create_unique_vertex(self, key=None, value=None, data=None, **pair):
+        """
+        Returns a tuple containing two values. The first is the element if it
+        was created / found. The second is a boolean value the tells whether
+        the element was created (True) or not (False).
+
+        :param key: The index key.
+        :type key: str
+
+        :param value: The key's value.
+        :type value: str or int
+
+        :param pair: Optional key/value pair. Example: name="James"
+        :type pair: key/value pair
+
+        :rtype: tuple
+
+        """
+        key, value = self._get_key_value(key,value,pair)
+        data = {} if data is None else data
+        create = self._get_method(vertex="create_unique_vertex")
+        resp = create(self.index_name, key, value, data)
+        if resp.total_size > 0:
+            result = get_one_result(resp)
+            was_created = resp.headers['status'] == '201'
+            return initialize_element(self.client, result), was_created
+        else:
+            return None, False
+
     def remove(self, _id, key=None, value=None, **pair):
         """
         Remove the element from the index located by key/value.


### PR DESCRIPTION
Based on [this feature](http://docs.neo4j.org/chunked/stable/rest-api-unique-indexes.html#rest-api-get-or-create-unique-node-create) of Neo4J's REST API.

I actually need this to avoid duplicate nodes in my application. It's my first contribution to this project, so if there's anything wrong with it, please let me know! =)
