### PR TITLE
Remove distribute from install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ def run_tests():
     return suite()
 
 # Python 3
-install_requires = ['distribute', 'httplib2>=0.7.2', 'pyyaml>=3.10', 'six', 'omnijson']
+install_requires = ['httplib2>=0.7.2', 'pyyaml>=3.10', 'six', 'omnijson']
 if sys.version < '3':
     install_requires.append('python-dateutil==1.5')
 else:


### PR DESCRIPTION
Turns out distribute is now a just a wrapper to setuptools. And we can assume setuptools is installed, after all it's imported at the top of the file (plus, `install_requires` is a setuptools feature).
